### PR TITLE
HASH verisi null dönme problemi çözüldü

### DIFF
--- a/AlgolabAPI/Program.cs
+++ b/AlgolabAPI/Program.cs
@@ -47,7 +47,8 @@ namespace AlgolabAPI
             Console.WriteLine("Sms Giriniz.");
             SMSCODE = Console.ReadLine();
             var control = LoginControl(token, SMSCODE);
-            HASH = control.Content.Hash;
+            HASH = control.Content.hash; // .Hash şeklinde kullanınca gelen veri otomatik "null" dönüyor,
+            // dolayısı ile diğer methodlarda Authorize problemi yaşanıyor.
 
 
             WebSocket.ConnectToWebsocket();


### PR DESCRIPTION
Response'nin içeriğindeki Content değişkenine gelen verinin key'i "hash" şeklinde olduğu için "control.Content.Hash" kullanımında gelen hash değeri otomatik null dönüyor, "control.Content.hash" yaptığımızda problem çözülüyor.